### PR TITLE
added join on savedPromos to display more location info

### DIFF
--- a/components/savedPromos/promos-model.js
+++ b/components/savedPromos/promos-model.js
@@ -36,12 +36,15 @@ function findBy(filter) {
   return query
     .findBy("savedPromos", filter)
     .join("promotions as p", "p.id", "savedPromos.promo_id")
+    .join("locations as l", "l.id", "p.location_id")
     .select(
       "p.location_id",
       "p.title",
       "p.text",
       "savedPromos.promo_id",
       "savedPromos.user_id",
-      "savedPromos.id"
+      "savedPromos.id",
+      "l.business_name",
+      "l.address"
     );
 }


### PR DESCRIPTION
# Description
Easier way to make it so that a users saved promotions display which location the promo is for 
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [X ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
- [X ] There are no merge conflicts
