### PR TITLE
Fix event time offset

### DIFF
--- a/data/migrations/20200415221904_events.js
+++ b/data/migrations/20200415221904_events.js
@@ -16,9 +16,9 @@ exports.up = function (knex, Promise) {
     //description
     events.string("description").notNullable();
     //start_time
-    events.datetime("start_time").notNullable();
+    events.datetime("start_time", options={ useTz: false }).notNullable();
     //end_time
-    events.datetime("end_time ").notNullable();
+    events.datetime('end_time ', options={ useTz: false }).notNullable();
   });
 };
 exports.down = function (knex, Promise) {


### PR DESCRIPTION
# Description

Events created or updated with specific start and end time, keeps returning with offset by UTC time.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
